### PR TITLE
Add support to controll what meta data is added to the order-meta-box

### DIFF
--- a/classes/class-briqpay-meta-box.php
+++ b/classes/class-briqpay-meta-box.php
@@ -42,11 +42,23 @@ class Briqpay_Meta_Box {
 	 * @return void
 	 */
 	public function meta_box_content() {
-		$order_id       = get_the_ID();
-		$payment_method = get_post_meta( $order_id, '_briqpay_payment_method', true );
-		$psp_name       = get_post_meta( $order_id, '_briqpay_psp_name', true );
-		$rules_results  = json_decode( get_post_meta( $order_id, '_briqpay_rules_result', true ), true );
-		$failed_rules   = $this->check_failed_rules( $rules_results );
+		$order_id          = get_the_ID();
+		$payment_method    = get_post_meta( $order_id, '_briqpay_payment_method', true );
+		$psp_name          = get_post_meta( $order_id, '_briqpay_psp_name', true );
+		$rules_results     = json_decode( get_post_meta( $order_id, '_briqpay_rules_result', true ), true );
+		$failed_rules      = $this->check_failed_rules( $rules_results );
+		$keys_for_meta_box = array(
+			array(
+				'title' => esc_html( 'Payment method', 'briqpay-for-woocommerce' ),
+				'value' => esc_html( $payment_method ),
+			),
+			array(
+				'title' => esc_html( 'PSP name', 'briqpay-for-woocommerce' ),
+				'value' => esc_html( $psp_name ),
+			),
+		);
+
+		$keys_for_meta_box = apply_filters( 'briqpay_meta_box_keys', $keys_for_meta_box );
 		include BRIQPAY_WC_PLUGIN_PATH . '/templates/briqpay-meta-box.php';
 	}
 

--- a/templates/briqpay-meta-box.php
+++ b/templates/briqpay-meta-box.php
@@ -4,18 +4,13 @@
  *
  * @package Briqpay_For_WooCommerce/Templates
  */
-$keysForMetaBox = [
-	["title" => esc_html( 'Payment method', 'briqpay-for-woocommerce' ),
-	"value" => esc_html( $payment_method )],
-	["title" => esc_html( 'PSP name', 'briqpay-for-woocommerce' ),
-	"value" => esc_html( $psp_name )]
-];
 
-$keysForMetaBox = apply_filters( 'briqpay_meta_box_keys', $keysForMetaBox );
+foreach ( $keys_for_meta_box as $item ) {
+	?>
+	<p><b><?php echo $item['title']; ?></b>: <?php echo $item['value']; ?></p>
+	<?php
+}
 ?>
-<?php foreach($keysForMetaBox as $item){
-	echo "<p><b>".$item['title']." : ".$item['value']."</b></p>";
-}?>
 <?php
 if ( ! empty( $rules_results ) && $failed_rules ) {
 	?>
@@ -28,7 +23,7 @@ if ( ! empty( $rules_results ) && $failed_rules ) {
 				<h4><?php echo esc_html( $psp_rules['pspname'] ); ?></h4>
 				<span><?php esc_html_e( 'This method was not shown because of the following rule was triggered', 'briqpay-for-woocommerce' ); ?></span>
 				<ul style="list-style: disc;
-    margin-left: 20px;">
+	margin-left: 20px;">
 				<?php
 				foreach ( $psp_rules['rulesResult'] as $rules_result ) {
 					if ( isset( $rules_result['outcome'] ) && ! $rules_result['outcome'] ) {

--- a/templates/briqpay-meta-box.php
+++ b/templates/briqpay-meta-box.php
@@ -6,15 +6,15 @@
  */
 $keysForMetaBox = [
 	["title" => esc_html( 'Payment method', 'briqpay-for-woocommerce' ),
-	"value" => echo esc_html( $payment_method )],
+	"value" => esc_html( $payment_method )],
 	["title" => esc_html( 'PSP name', 'briqpay-for-woocommerce' ),
-	"value" => echo esc_html( $psp_name )]
-	]
+	"value" => esc_html( $psp_name )]
+];
 
-$keysForMetaBox = apply_filter( 'briqpay_meta_box_keys', $keysForMetaBox );
+$keysForMetaBox = apply_filters( 'briqpay_meta_box_keys', $keysForMetaBox );
 ?>
 <?php foreach($keysForMetaBox as $item){
-	echo "<p><b>".$item['title'].":".$item['value']."</b></p>";
+	echo "<p><b>".$item['title']." : ".$item['value']."</b></p>";
 }?>
 <?php
 if ( ! empty( $rules_results ) && $failed_rules ) {

--- a/templates/briqpay-meta-box.php
+++ b/templates/briqpay-meta-box.php
@@ -4,11 +4,18 @@
  *
  * @package Briqpay_For_WooCommerce/Templates
  */
+$keysForMetaBox = [
+	["title" => esc_html( 'Payment method', 'briqpay-for-woocommerce' ),
+	"value" => echo esc_html( $payment_method )],
+	["title" => esc_html( 'PSP name', 'briqpay-for-woocommerce' ),
+	"value" => echo esc_html( $psp_name )]
+	]
 
+$keysForMetaBox = apply_filter( 'briqpay_meta_box_keys', $keysForMetaBox );
 ?>
-
-<p><b><?php esc_html_e( 'Payment method', 'briqpay-for-woocommerce' ); ?>:</b> <?php echo esc_html( $payment_method ); ?></p>
-<p><b><?php esc_html_e( 'PSP name', 'briqpay-for-woocommerce' ); ?>:</b> <?php echo esc_html( $psp_name ); ?></p>
+<?php foreach($keysForMetaBox as $item){
+	echo "<p><b>".$item['title'].":".$item['value']."</b></p>";
+}?>
 <?php
 if ( ! empty( $rules_results ) && $failed_rules ) {
 	?>


### PR DESCRIPTION
example usage:

function example_callback_add_more_meta_keys( $meta_box_keys ) {
    $meta_box_keys[] = ["title"=>"My TItle", "value" => "MyAdditionalData"];
    return $meta_box_keys;
}
add_filter( 'briqpay_meta_box_keys', 'example_callback_add_more_meta_keys', 10, 1 );
