### PR TITLE
Add support for HPOS

### DIFF
--- a/briqpay-for-woocommerce.php
+++ b/briqpay-for-woocommerce.php
@@ -218,6 +218,20 @@ if ( ! class_exists( 'Briqpay_For_WooCommerce' ) ) {
 
 			$this->api              = new Briqpay_API();
 			$this->order_management = new Briqpay_Order_Management();
+
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
+		}
+
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+		public function declare_wc_compatibility() {
+			// Declare HPOS compatibility.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
 		}
 
 		/**

--- a/classes/class-briqpay-api.php
+++ b/classes/class-briqpay-api.php
@@ -50,7 +50,9 @@ class Briqpay_API {
 	public function create_briqpay_hpp( $order_id, $type ) {
 		$briqpay_order = $this->create_predefined_briqpay_order( $order_id );
 
-		update_post_meta( $order_id, '_briqpay_session_id', $briqpay_order['sessionid'] );
+		$order = wc_get_order( $order_id );
+		$order->update_meta_data( '_briqpay_session_id', $briqpay_order['sessionid'] );
+		$order->save();
 
 		$this->patch_briqpay_order(
 			array(
@@ -59,7 +61,6 @@ class Briqpay_API {
 			)
 		);
 
-		$order       = wc_get_order( $order_id );
 		$phone       = $order->get_billing_phone();
 		$destination = $phone;
 
@@ -163,14 +164,12 @@ class Briqpay_API {
 	 * @return array|mixed
 	 */
 	public function update_briqpay_order_orm( $order_id ) {
+		$order = wc_get_order( $order_id );
+
 		$request  = new Briqpay_Request_ORM_Update(
 			array(
 				'order_id'   => $order_id,
-				'session_id' => get_post_meta(
-					$order_id,
-					'_briqpay_session_id',
-					true
-				),
+				'session_id' => $order->get_meta( $order_id, '_briqpay_session_id' ),
 			),
 			true
 		);

--- a/classes/class-briqpay-confirmation.php
+++ b/classes/class-briqpay-confirmation.php
@@ -79,34 +79,34 @@ class Briqpay_Confirmation {
 			return;
 		}
 
-		$session_id    = get_post_meta( $order_id, '_briqpay_session_id', true );
+		$session_id    = $order->get_meta( '_briqpay_session_id' );
 		$briqpay_order = BRIQPAY()->api->get_briqpay_order( array( 'session_id' => $session_id ) );
 
 		// Set post meta and complete order.
-		update_post_meta( $order_id, '_shipping_phone', $briqpay_order['shippingaddress']['cellno'] );
-		update_post_meta( $order_id, '_shipping_email', $briqpay_order['shippingaddress']['email'] );
-		update_post_meta( $order_id, '_briqpay_payment_method', $briqpay_order['purchasepaymentmethod']['name'] );
-		update_post_meta( $order_id, '_briqpay_psp_name', $briqpay_order['purchasepaymentmethod']['pspname'] );
-		update_post_meta( $order_id, '_briqpay_autocapture', $briqpay_order['purchasepaymentmethod']['autocapture'] );
-		update_post_meta( $order_id, '_briqpay_rules_result', wp_json_encode( $briqpay_order['rulesresult'] ?? array() ) );
-		update_post_meta( $order_id, '_billing_org_nr', $briqpay_order['orgnr'] );
+		$order->update_meta_data( '_shipping_phone', $briqpay_order['shippingaddress']['cellno'] );
+		$order->update_meta_data( '_shipping_email', $briqpay_order['shippingaddress']['email'] );
+		$order->update_meta_data( '_briqpay_payment_method', $briqpay_order['purchasepaymentmethod']['name'] );
+		$order->update_meta_data( '_briqpay_psp_name', $briqpay_order['purchasepaymentmethod']['pspname'] );
+		$order->update_meta_data( '_briqpay_autocapture', $briqpay_order['purchasepaymentmethod']['autocapture'] );
+		$order->update_meta_data( '_briqpay_rules_result', wp_json_encode( $briqpay_order['rulesresult'] ?? array() ) );
+		$order->update_meta_data( '_billing_org_nr', $briqpay_order['orgnr'] );
 
 		$purchase_payment_method = $briqpay_order['purchasepaymentmethod'];
 		if ( isset( $purchase_payment_method['pspSupportedOrderOperations'] ) ) {
 			if ( true === $purchase_payment_method['pspSupportedOrderOperations']['updateOrderSupported'] ) {
-				update_post_meta( $order_id, '_briqpay_psp_update_order_supported', $purchase_payment_method['pspSupportedOrderOperations']['updateOrderSupported'] );
+				$order->update_meta_data( '_briqpay_psp_update_order_supported', $purchase_payment_method['pspSupportedOrderOperations']['updateOrderSupported'] );
 			}
 		}
 
 		$order->set_payment_method_title( $briqpay_order['purchasepaymentmethod']['name'] );
 		$order->add_order_note( __( 'Payment via Briqpay, session ID: ', 'briqpay-for-woocommerce' ) . $session_id );
+		$order->save();
+
 		if ( 'purchasecomplete' == $briqpay_order['state'] ) {
 			$order->payment_complete( $session_id );
 		}
-
 		do_action( 'briqpay_order_confirmed', $briqpay_order, $order );
 	}
-
 }
 
 Briqpay_Confirmation::get_instance();

--- a/classes/class-briqpay-gateway.php
+++ b/classes/class-briqpay-gateway.php
@@ -67,7 +67,9 @@ class Briqpay_Gateway extends WC_Payment_Gateway {
 			);
 		}
 
-		update_post_meta( $order_id, '_briqpay_session_id', $response['sessionid'] );
+		$order = wc_get_order( $order_id );
+		$order->update_meta_data( '_briqpay_session_id', $response['sessionid'] );
+		$order->save();
 
 		$v2_result = $this->maybe_handle_v2_result( true, $session_id );
 
@@ -80,7 +82,6 @@ class Briqpay_Gateway extends WC_Payment_Gateway {
 		return array(
 			'result' => 'success',
 		);
-
 	}
 
 	/**
@@ -148,8 +149,7 @@ class Briqpay_Gateway extends WC_Payment_Gateway {
 	 */
 	public function add_billing_org_nr( $order ) {
 		if ( $this->id === $order->get_payment_method() ) {
-			$order_id = $order->get_id();
-			$org_nr   = get_post_meta( $order_id, '_billing_org_nr', true );
+			$org_nr = $order->get_meta( '_billing_org_nr' );
 			if ( $org_nr ) {
 				?>
 				<p>
@@ -169,8 +169,7 @@ class Briqpay_Gateway extends WC_Payment_Gateway {
 	 */
 	public function add_shipping_email( $order ) {
 		if ( $this->id === $order->get_payment_method() ) {
-			$order_id       = $order->get_id();
-			$shipping_email = get_post_meta( $order_id, '_shipping_email', true );
+			$shipping_email = $order->get_meta( '_shipping_email' );
 			if ( $shipping_email ) {
 				?>
 				<p>
@@ -191,8 +190,7 @@ class Briqpay_Gateway extends WC_Payment_Gateway {
 	 */
 	public function add_shipping_phone( $order ) {
 		if ( $this->id === $order->get_payment_method() ) {
-			$order_id       = $order->get_id();
-			$shipping_phone = get_post_meta( $order_id, '_shipping_phone', true );
+			$shipping_phone = $order->get_meta( '_shipping_phone' );
 			if ( $shipping_phone ) {
 				?>
 				<p>

--- a/classes/class-briqpay-meta-box.php
+++ b/classes/class-briqpay-meta-box.php
@@ -47,9 +47,6 @@ class Briqpay_Meta_Box {
 		$order_id             = get_the_ID();
 		$payment_method       = get_post_meta( $order_id, '_briqpay_payment_method', true );
 		$psp_name             = get_post_meta( $order_id, '_briqpay_psp_name', true );
-		$hpp_session_id       = get_post_meta( $order_id, '_briqpay_hpp_session_id', true );
-		$rules_results        = json_decode( get_post_meta( $order_id, '_briqpay_rules_result', true ), true );
-		$failed_rules         = $this->check_failed_rules( $rules_results );
 		$title_payment_method = __( 'Payment method', 'briqpay-for-woocommerce' );
 		$title_psp_name       = __( 'PSP name', 'briqpay-for-woocommerce' );
 
@@ -119,5 +116,4 @@ class Briqpay_Meta_Box {
 		}
 		return false;
 	}
-
 } new Briqpay_Meta_Box();

--- a/classes/class-briqpay-order-management.php
+++ b/classes/class-briqpay-order-management.php
@@ -80,7 +80,7 @@ class Briqpay_Order_Management {
 		}
 
 		// If this reservation was already activated, do nothing.
-		if ( get_post_meta( $order_id, '_capture_id_', true ) ) {
+		if ( $order->get_meta( '_capture_id_' ) ) {
 			$order->add_order_note(
 				__(
 					'Could not activate Briqpay reservation, Briqpay reservation is already activated.',
@@ -102,7 +102,7 @@ class Briqpay_Order_Management {
 
 		if ( is_array( $response ) && ! is_wp_error( $response ) ) {
 			$capture_id = $response['captureid'];
-			update_post_meta( $order_id, '_capture_id_', $capture_id );
+			$order->update_meta_data( '_capture_id_', $capture_id );
 			$order->add_order_note(
 				__(
 					'Briqpay reservation was successfully activated.',
@@ -117,8 +117,8 @@ class Briqpay_Order_Management {
 				)
 			);
 			$order->set_status( 'on-hold' );
-			$order->save();
 		}
+		$order->save();
 	}
 
 
@@ -145,7 +145,7 @@ class Briqpay_Order_Management {
 			return false;
 		}
 		// translators: refund amount, refund id.
-		$text           = __( '%1$s successfully refunded in Briqpay.. RefundID: %2$s', 'briqpay-for-woocommerce' );
+		$text           = __( '%1$s successfully refunded in Briqpay. RefundID: %2$s', 'briqpay-for-woocommerce' );
 		$formatted_text = sprintf( $text, wc_price( $amount ), $response['refundid'] );
 		$order->add_order_note( $formatted_text );
 		return true;
@@ -163,7 +163,7 @@ class Briqpay_Order_Management {
 			return $url;
 		}
 
-		$hpp_url = get_post_meta( $order->get_id(), '_briqpay_hpp_url', true );
+		$hpp_url = $order->get_meta( '_briqpay_hpp_url' );
 
 		if ( ! empty( $hpp_url ) ) {
 			$url = $hpp_url;
@@ -204,6 +204,8 @@ class Briqpay_Order_Management {
 	 */
 	public function save_org_nr_to_order( $post_id ) {
 		$org_number = filter_input( INPUT_POST, '_billing_org_nr', FILTER_SANITIZE_SPECIAL_CHARS );
-		update_post_meta( $post_id, '_billing_org_nr', $org_number );
+		$order      = wc_get_order( $post_id );
+		$order->update_meta_data( '_billing_org_nr', $org_number );
+		$order->save();
 	}
 }

--- a/classes/requests/post/class-briqpay-request-capture.php
+++ b/classes/requests/post/class-briqpay-request-capture.php
@@ -31,7 +31,7 @@ class Briqpay_Request_Capture extends Briqpay_Request_Post {
 		return apply_filters(
 			'briqpay_capture_args',
 			array(
-				'sessionid' => get_post_meta( $this->arguments['order_id'], '_briqpay_session_id', true ),
+				'sessionid' => $order->get_meta( '_briqpay_session_id' ),
 				'amount'    => Briqpay_Helper_Order_Lines::get_order_amount( $order ),
 				'cart'      => Briqpay_Helper_Order_Lines::get_order_lines( $order ),
 			),

--- a/classes/requests/post/class-briqpay-request-capture.php
+++ b/classes/requests/post/class-briqpay-request-capture.php
@@ -31,7 +31,7 @@ class Briqpay_Request_Capture extends Briqpay_Request_Post {
 		return apply_filters(
 			'briqpay_capture_args',
 			array(
-				'sessionid' => $order->get_meta( '_briqpay_session_id' ),
+				'sessionid' => is_object( $order ) ? $order->get_meta( '_briqpay_session_id' ) : '',
 				'amount'    => Briqpay_Helper_Order_Lines::get_order_amount( $order ),
 				'cart'      => Briqpay_Helper_Order_Lines::get_order_lines( $order ),
 			),

--- a/classes/requests/post/class-briqpay-request-create-predefined-order.php
+++ b/classes/requests/post/class-briqpay-request-create-predefined-order.php
@@ -39,7 +39,7 @@ class Briqpay_Request_Create_Predefined_Order extends Briqpay_Request_Post {
 				'merchantconfig'  => Briqpay_Helper_Merchant_Config::get_config( $order_id, false ),
 				'cart'            => Briqpay_Helper_Order_Lines::get_order_lines( $order, false ),
 				'amount'          => $amount,
-				'orgnr'           => get_post_meta( $order_id, '_billing_org_nr', true ),
+				'orgnr'           => $order->get_meta( '_billing_org_nr' ),
 				'billingaddress'  => Briqpay_Helper_Customer::get_billing_data_order( $order ),
 				'shippingaddress' => Briqpay_Helper_Customer::get_shipping_data_order( $order ),
 			)

--- a/classes/requests/post/class-briqpay-request-create-predefined-order.php
+++ b/classes/requests/post/class-briqpay-request-create-predefined-order.php
@@ -34,12 +34,12 @@ class Briqpay_Request_Create_Predefined_Order extends Briqpay_Request_Post {
 			array(
 				'currency'        => get_woocommerce_currency(),
 				'locale'          => str_replace( '_', '-', strtolower( get_locale() ) ),
-				'country'         => $order->get_billing_country(),
+				'country'         => is_object( $order ) ? $order->get_billing_country() : '',
 				'merchanturls'    => Briqpay_Helper_MerchantUrls::get_urls( $order_id ),
 				'merchantconfig'  => Briqpay_Helper_Merchant_Config::get_config( $order_id, false ),
 				'cart'            => Briqpay_Helper_Order_Lines::get_order_lines( $order, false ),
 				'amount'          => $amount,
-				'orgnr'           => $order->get_meta( '_billing_org_nr' ),
+				'orgnr'           => is_object( $order ) ? $order->get_meta( '_billing_org_nr' ) : '',
 				'billingaddress'  => Briqpay_Helper_Customer::get_billing_data_order( $order ),
 				'shippingaddress' => Briqpay_Helper_Customer::get_shipping_data_order( $order ),
 			)

--- a/classes/requests/post/class-briqpay-request-orm-update.php
+++ b/classes/requests/post/class-briqpay-request-orm-update.php
@@ -31,7 +31,7 @@ class Briqpay_Request_ORM_Update extends Briqpay_Request_Post {
 		return apply_filters(
 			'briqpay_update_orm_order',
 			array(
-				'sessionid'       => $order->get_meta( '_briqpay_session_id' ),
+				'sessionid'       => is_object( $order ) ? $order->get_meta( '_briqpay_session_id' ) : '',
 				'amount'          => Briqpay_Helper_Order_Lines::get_order_amount( $order, false ),
 				'billingaddress'  => Briqpay_Helper_Customer::get_billing_data_order( $order ),
 				'shippingaddress' => Briqpay_Helper_Customer::get_shipping_data_order( $order ),

--- a/classes/requests/post/class-briqpay-request-orm-update.php
+++ b/classes/requests/post/class-briqpay-request-orm-update.php
@@ -31,7 +31,7 @@ class Briqpay_Request_ORM_Update extends Briqpay_Request_Post {
 		return apply_filters(
 			'briqpay_update_orm_order',
 			array(
-				'sessionid'       => get_post_meta( $order->get_id(), '_briqpay_session_id', true ),
+				'sessionid'       => $order->get_meta( '_briqpay_session_id' ),
 				'amount'          => Briqpay_Helper_Order_Lines::get_order_amount( $order, false ),
 				'billingaddress'  => Briqpay_Helper_Customer::get_billing_data_order( $order ),
 				'shippingaddress' => Briqpay_Helper_Customer::get_shipping_data_order( $order ),

--- a/includes/briqpay-functions.php
+++ b/includes/briqpay-functions.php
@@ -224,20 +224,21 @@ function briqpay_is_order_type( $post = null ) {
 }
 
 /**
- * Get a order id from the merchant reference.
+ * Get Woo order ID from session ID.
  *
- * @param string $merchant_reference The merchant reference from Briqpay.
- * @return int The WC order ID or 0 if no match was found.
+ * @param string $session_id The session ID from Briqpay.
+ * @return int The Woo order ID or 0 if no match was found.
  */
 function briqpay_get_order_id_by_session_id( $session_id ) {
 	$key    = '_briqpay_session_id';
 	$orders = wc_get_orders(
 		array(
-			'meta_key'   => $key,
-			'meta_value' => $session_id,
-			'limit'      => 1,
-			'orderby'    => 'date',
-			'order'      => 'DESC',
+			'meta_key'     => $key,
+			'meta_value'   => $session_id,
+			'meta_compare' => '=',
+			'orderby'      => 'date',
+			'order'        => 'DESC',
+			'limit'        => 1,
 		)
 	);
 

--- a/includes/briqpay-functions.php
+++ b/includes/briqpay-functions.php
@@ -7,6 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 /**
  * Gets a Briqpay order. Either creates or updates existing order
  *
@@ -103,10 +105,8 @@ function briqpay_extract_error_message( $wp_error ) {
 		if ( function_exists( 'wc_add_notice' ) ) {
 			wc_add_notice( $error_message, 'error' );
 		}
-	} else {
-		if ( function_exists( 'wc_print_notice' ) ) {
+	} elseif ( function_exists( 'wc_print_notice' ) ) {
 			wc_print_notice( $error_message, 'error' );
-		}
 	}
 }
 
@@ -158,4 +158,93 @@ function validate_credentials() {
 	}
 
 	return false;
+}
+
+/**
+ * Similar to WP's get_the_ID() with HPOS support. Used for retrieving the current order/post ID.
+ *
+ * Unlike get_the_ID() function, if `id` is missing, we'll default to the `post` query parameter when HPOS is disabled.
+ *
+ * @return int|false the order ID or false.
+ */
+//phpcs:ignore
+function briqpay_get_the_ID() {
+	$hpos_enabled = briqpay_is_hpos_enabled();
+	$order_id     = $hpos_enabled ? filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT ) : get_the_ID();
+	if ( empty( $order_id ) ) {
+		if ( ! $hpos_enabled ) {
+			$order_id = absint( filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT ) );
+			return empty( $order_id ) ? false : $order_id;
+		}
+		return false;
+	}
+
+	return absint( $order_id );
+}
+
+/**
+ * Whether HPOS is enabled.
+ *
+ * @return bool true if HPOS is enabled, otherwise false.
+ */
+function briqpay_is_hpos_enabled() {
+	// CustomOrdersTableController was introduced in WC 6.4.
+	if ( class_exists( CustomOrdersTableController::class ) ) {
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+	}
+
+	return false;
+}
+
+/**
+ * Retrieves the post type of the current post or of a given post.
+ *
+ * Compatible with HPOS.
+ *
+ * @param int|WP_Post|WC_Order|null $post Order ID, post object or order object.
+ * @return string|null|false Return type of passed id, post or order object on success, false or null on failure.
+ */
+function briqpay_get_post_type( $post = null ) {
+	if ( ! briqpay_is_hpos_enabled() ) {
+		return get_post_type( $post );
+	}
+
+	return ! class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ? false : Automattic\WooCommerce\Utilities\OrderUtil::get_order_type( $post );
+}
+
+
+/**
+ * Retrieves the post type of the current post or of a given post.
+ *
+ * @param int|WP_Post|WC_Order|null $post Order ID, post object or order object.
+ * @return true if order type, otherwise false.
+ */
+function briqpay_is_order_type( $post = null ) {
+	return in_array( briqpay_get_post_type( $post ), array( 'woocommerce_page_wc-orders', 'shop_order' ), true );
+}
+
+/**
+ * Get a order id from the merchant reference.
+ *
+ * @param string $merchant_reference The merchant reference from Briqpay.
+ * @return int The WC order ID or 0 if no match was found.
+ */
+function briqpay_get_order_id_by_session_id( $session_id ) {
+	$key    = '_briqpay_session_id';
+	$orders = wc_get_orders(
+		array(
+			'meta_key'   => $key,
+			'meta_value' => $session_id,
+			'limit'      => 1,
+			'orderby'    => 'date',
+			'order'      => 'DESC',
+		)
+	);
+
+	$order = reset( $orders );
+	if ( empty( $order ) || $session_id !== $order->get_meta( $key ) ) {
+		return 0;
+	}
+
+	return $order->get_id() ?? 0;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: krokedil
 Tags: woocommerce, briqpay, ecommerce, e-commerce, checkout
 Donate link: https://krokedil.com
 Requires at least: 5.0
-Tested up to: 6.4.2
+Tested up to: 6.5.3
 Requires PHP: 7.0
 WC requires at least: 4.0.0
-WC tested up to: 8.5.1
+WC tested up to: 8.8.3
 Stable tag: 1.6.6
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/templates/briqpay-meta-box.php
+++ b/templates/briqpay-meta-box.php
@@ -21,7 +21,7 @@ if ( $order->get_status() === 'pending' && strtolower( $order->get_payment_metho
 		<p><b><?php echo esc_html( $item['title'] ); ?></b>: <?php echo esc_html( $item['value'] ); ?></p>
 		<?php
 	}
-	if ( get_post_meta( $order_id, '_briqpay_psp_update_order_supported', true ) && ( 'completed' !== $order->get_status() ) ) {
+	if ( $order->get_meta( '_briqpay_psp_update_order_supported' ) && ( 'completed' !== $order->get_status() ) ) {
 		?>
 		<div class="briqpay_sync_wrapper">
 			<button class="button-primary sync-btn-briqpay"><?php esc_html_e( 'Sync order to Briqpay', 'briqpay-for-woocommerce' ); ?></button>


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):

### Functions and methods
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`
- `get_post_meta` → `WC_Order::get_meta`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and `update_meta_data` is still used, WooCommerce will warn about directly modifying internal meta data.

**Note:**
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.


### Hooks
- `manage_edit-shop_order_columns` → `woocommerce_shop_order_list_table_columns`
- `manage_shop_order_posts_custom_column` → `woocommerce_shop_order_list_table_custom_column `
- `bulk_actions-edit-shop_order` →` bulk_actions-woocommerce_page_wc-orders`
- `handle_bulk_actions-edit-shop_order`  → `handle_bulk_actions-woocommerce_page_wc-orders`
- `bulk_actions-edit-shop_subscription`  →  `bulk_actions-woocommerce_page_wc-orders--shop_subscription`